### PR TITLE
Update GPR file instructions to also with ravenscar_build.gpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Using the `light_tasking_rp2040` runtime as an example, first edit your
    ```
 
 Then edit your project file to add the following elements:
- - "with" the run-time project file:
+ - "with" the run-time project files:
    ```ada
    with "runtime_build.gpr";
+   with "ravenscar_build.gpr";
    ```
  - specify the `Target` and `Runtime` attributes:
    ```ada

--- a/templates/rp2040/alire.toml.in
+++ b/templates/rp2040/alire.toml.in
@@ -13,9 +13,10 @@ First edit your `alire.toml` file and add the following elements:
    ```
 
 Then edit your project file to add the following elements:
- - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+ - "with" the run-time project files. With this, gprbuild will compile the run-time before your application
    ```ada
    with "runtime_build.gpr";
+   with "ravenscar_build.gpr";
    ```
  - Specify the `Target` and `Runtime` attributes:
    ```ada

--- a/templates/rp2350/alire.toml.in
+++ b/templates/rp2350/alire.toml.in
@@ -13,9 +13,10 @@ First edit your `alire.toml` file and add the following elements:
    ```
 
 Then edit your project file to add the following elements:
- - "with" the run-time project file. With this, gprbuild will compile the run-time before your application
+ - "with" the run-time project files. With this, gprbuild will compile the run-time before your application
    ```ada
    with "runtime_build.gpr";
+   with "ravenscar_build.gpr";
    ```
  - Specify the `Target` and `Runtime` attributes:
    ```ada


### PR DESCRIPTION
The current instructions tell the user to "with" runtime_build.gpr only in their project file. For light-tasking/embedded runtimes Alire normally auto-withs ravenscar_build.gpr in the auto-generated config file. But if the user doesn't "with" that config in their main project file, or if Alire is configured with auto-with-gpr=false then ravenscar_build.gpr will not get built, leading to errors when building complaining that ali files for libgnarl units don't exist.

These new instructions tell the user to "with" ravenscar_build.gpr in their project file to ensure libgnarl gets built without relying on Alire.